### PR TITLE
Updates + fixes

### DIFF
--- a/markdown/patchnotes/changelogs/IOS.md
+++ b/markdown/patchnotes/changelogs/IOS.md
@@ -73,7 +73,7 @@ This release is identical to v2.0, except with a fix for issues installing on Pr
 ## 2.0 "Raw Iron"
 ### Changes
 - The Login view has been simplified to three easy buttons
-- The Offline Account has been replaced with [Local Account](https://pojavlauncherteam.github.io/updates/local.html). Installing Minecraft now requires a Mojang or Microsoft account logged in.
+- The Offline Account has been replaced with [Local Account](https://wiki.angelauramc.dev/patchnotes/LOCAL-MODE.html). Installing Minecraft now requires a Mojang or Microsoft account logged in.
 - New FAQ page to show quick answers to questions
 - New About view to show quick details, links, and update history
 - Ability to send logs from within the launcher

--- a/markdown/wiki/faq/android/RENDERERS.md
+++ b/markdown/wiki/faq/android/RENDERERS.md
@@ -39,7 +39,7 @@ As of Galdiolus release, ANGLE renderer has been removed/replaced with LTW, We h
 **will** face crashes when using Zink.
 - Works on all vanilla versions of Minecraft.
 
-> On the current version of PojavLauncher, Mali with Vulkan 1.1 or some Vulkan 1.3 driver (need more testers with Mali Vulkan 1.3 devices). cannot run Minecraft 1.16.5 and below with Zink due to Mali driver issue with Mesa 23.2.0-devel (MESA_GL_VERSION_OVERRIDE=<api version> (See https://pojavlauncher.app/wiki/faq/android/ZINKNOTWORKING.html). will not fix this issue)
+> On the current version of PojavLauncher, Mali with Vulkan 1.1 or some Vulkan 1.3 driver (need more testers with Mali Vulkan 1.3 devices). cannot run Minecraft 1.16.5 and below with Zink due to Mali driver issue with Mesa 23.2.0-devel (MESA_GL_VERSION_OVERRIDE=<api version> (See https://wiki.angelauramc.dev/wiki/faq/android/ZINKNOTWORKING.html). will not fix this issue)
 > (*) Most Mali GPUs can only run OpenGL 3.1
 
 ### A screenshot of Zink running Minecraft 1.21.1

--- a/markdown/wiki/faq/ios/JIT.md
+++ b/markdown/wiki/faq/ios/JIT.md
@@ -19,17 +19,15 @@ Users with Unjailbroken devices can see two different outcomes, based on what th
 If you used TrollStore to sideload PojavLauncher, good news: PojavLauncher takes advantage of the extended entitlements granted by TrollStore and automatically enables JIT when launched. **(Turn on URL Schemes)**
 
 #### Normal sideload
-If you sideload normally, you will need to enable JIT in some way. The most common method is to attach a debug server to the application while it's running - AltStore, SideStore, SideJITServer, and Jitterbug all of these use this method to enable JIT. 
+If you sideload normally, you will need to enable JIT in some way. The most common method is to attach a debug server to the application while it's running - AltStore, SideStore, StikDebug, SideJITServer, and Jitterbug all use this method to enable JIT. 
 
-The only downside to this method is that you are required to be connected to a WiFi network in order to enable JIT. (*)
-
-(*) - Enabling JIT on iOS 17.0.1+ (at the moment) can only be enabled through different various methods listed below that utilize pymobiledevice3 to enable JIT due to changes in iOS. 
+The only downside to this method is that you are often required to be connected to a Wi-Fi network in order to enable JIT. 
 
 ## What are the methods to enable JIT?
 
-The methods to enable JIT can be found [here](https://github.com/ItAnthon/JIT-on-iOS).
+The methods to enable JIT for each iOS version can be found [here](https://github.com/C4ndyF1sh/iOS-JIT-Enablers).
 
-Methods not listed here are not confirmed or recommended by us for use with PojavLauncher.
+Methods not listed underneath are not confirmed nor recommended by us for use with PojavLauncher.
 
 ## So how do I enable JIT?
 
@@ -41,9 +39,11 @@ Methods not listed here are not confirmed or recommended by us for use with Poja
 
 - [Jitterbug](https://github.com/osy/Jitterbug/tree/main/Jitterbug) ($)
 
-- [SideStore](https://docs.sidestore.io/docs/faq#can-i-activate-jit) ($)
+- [SideStore](https://docs.sidestore.io/docs/faq#can-i-activate-jit) ($), [nightly](https://github.com/SideStore/SideStore/releases/nightly) (^)
 
 - [SideJITServer](https://github.com/nythepegasus/SideJITServer) (%)
+
+- [StikDebug](https://github.com/StephenDev0/StikDebug) (^)
 
 (!) - Limited to Jailbroken devices only. (JIT is granted by the Jailbreak itself)
 
@@ -55,10 +55,8 @@ Methods not listed here are not confirmed or recommended by us for use with Poja
 
 (%) - Does not work for iOS 16.x or below, use the other methods listed above to enable JIT. This method is meant for iOS 17.0.1+
 
+(^) - iOS 17.4+ Only
+
 ## Methods coming Soon:
 
-- JITStreamer 2.0 (^)
-
 - UTM SE (^)
-
-(^) - iOS 17.4+ Only


### PR DESCRIPTION
Updates JIT.md with StikDebug, replaces “list of JIT enablers” link with an active one, fixes a couple old pojavlauncher.app and github.io links (not all of them, just a couple fixes because spare time why not)