### PR TITLE
Update Java version recommendations for Minecraft and fixed formatting

### DIFF
--- a/markdown/wiki/faq/JAVAVERSION.md
+++ b/markdown/wiki/faq/JAVAVERSION.md
@@ -1,7 +1,9 @@
 # Which Java version to use?
 
 Generally, this is what you want to know:
-	- Minecraft 1.17 and newer: Java 21
-	- Minecraft 1.16.5 and older: Java 8 
 
-Note: some modded Minecraft versions require a different Java runtime than normal (e. g. Cursed Fabric or Babric for Minecraft b1.7.3). Others might work even when using a different runtime (e. g. Fabric for Minecraft 1.16.5 allows using Java 17). However, some mods, notably OptiFabric, might stop working altogether.
+	● Minecraft 26.1 and newer: Java 25
+	● Minecraft 1.17 to 1.21.x: Java 21
+	● Minecraft 1.16.5 and older: Java 8
+
+**Note:** some modded Minecraft versions require a different Java runtime than normal (e. g. Cursed Fabric or Babric for Minecraft b1.7.3). Others might work even when using a different runtime (e. g. Fabric for Minecraft 1.16.5 allows using Java 17). However, some mods, notably OptiFabric, might stop working altogether.


### PR DESCRIPTION
1.  Added info for the Java version required for Minecraft 26.1 and later
2. Fixed formatting so that text appears on a line break
3. Rewritten in bold "Note:"